### PR TITLE
chore(flake/nixpkgs): `063dece0` -> `c8cd8142`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743964447,
-        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`a19cd4ff`](https://github.com/NixOS/nixpkgs/commit/a19cd4ffb1f4b953a76f3ac29c6520d0b1877108) | `` Revert "treewide: replace `rev` with `tag`" ``                                                       |
| [`3640e17c`](https://github.com/NixOS/nixpkgs/commit/3640e17ca3376d8916bb66ccee545ac4be8f7403) | `` icloudpd: 1.27.1 -> 1.27.2 ``                                                                        |
| [`94492d91`](https://github.com/NixOS/nixpkgs/commit/94492d91e9da931cf833200c12f8d773bc4f38d0) | `` cpplint: 2.0.1 -> 2.0.2 ``                                                                           |
| [`a6d91cd3`](https://github.com/NixOS/nixpkgs/commit/a6d91cd3f8238f6c36109661ba7b6f03425c567a) | `` airwindows: 0-unstable-2025-03-23 -> 0-unstable-2025-04-06 ``                                        |
| [`eb63ed5b`](https://github.com/NixOS/nixpkgs/commit/eb63ed5b3fe75056f9450ba04838bc3d8e957d22) | `` simdutf: 6.2.1 -> 6.4.2 ``                                                                           |
| [`ab9d81ee`](https://github.com/NixOS/nixpkgs/commit/ab9d81ee014151de9c205f4834cd10771b6ca4ae) | `` parca-agent: 0.36.0 -> 0.37.0 ``                                                                     |
| [`cc02c9ee`](https://github.com/NixOS/nixpkgs/commit/cc02c9ee3324a3091804ab0dd3e9148d31a3ab10) | `` github-mcp-server: 0.1.0 -> 0.1.1 ``                                                                 |
| [`a9691ce7`](https://github.com/NixOS/nixpkgs/commit/a9691ce732e26df12f0f2cbe4a91dc9f3d375527) | `` music-assistant: yank broken airplay support ``                                                      |
| [`1033d92c`](https://github.com/NixOS/nixpkgs/commit/1033d92c02a3f34630431fc13abecabed5945ce1) | `` flutter324: 3.24.4 -> 3.24.5 ``                                                                      |
| [`b429401c`](https://github.com/NixOS/nixpkgs/commit/b429401c30b208f5ebd40f70425f323a69cc366a) | `` pixi-pack: 0.3.3 -> 0.5.0 ``                                                                         |
| [`6d3624e3`](https://github.com/NixOS/nixpkgs/commit/6d3624e305d6de091685cefe214b0df8c3bade5f) | `` nixVersions.git: Reintroduce ``                                                                      |
| [`7c0b894e`](https://github.com/NixOS/nixpkgs/commit/7c0b894e3d9d98cdda81ca9eb131708339a77182) | `` synapse-admin: add meta.changelog ``                                                                 |
| [`bdcdeb71`](https://github.com/NixOS/nixpkgs/commit/bdcdeb7111490f682ffbdced5e94c996593ac853) | `` synapse-admin: add updateScript ``                                                                   |
| [`73bd9906`](https://github.com/NixOS/nixpkgs/commit/73bd9906eabab61c180fbb31173b3d6173dddc0f) | `` synapse-admin: 0.10.0 -> 0.10.3 ``                                                                   |
| [`e2869b81`](https://github.com/NixOS/nixpkgs/commit/e2869b813e817b662694bbd3b084c9e2d7c79206) | `` linux/common-config: SCHED_DEBUG is removed in 6.15 ``                                               |
| [`04e44c5d`](https://github.com/NixOS/nixpkgs/commit/04e44c5dc23338994c64a508e32fd7dda9f8cbcc) | `` cnsprcy: fix updateScript ``                                                                         |
| [`f457793b`](https://github.com/NixOS/nixpkgs/commit/f457793bb9eeced95440c4269e1fc044c634df6c) | `` python312Packages.django-cms: 4.1.4 -> 4.1.5 ``                                                      |
| [`134bc9de`](https://github.com/NixOS/nixpkgs/commit/134bc9de5348cc783b4cb3283ea9b920d92cf2d6) | `` adminer: 5.1.0 -> 5.1.1 ``                                                                           |
| [`fa6c1b73`](https://github.com/NixOS/nixpkgs/commit/fa6c1b73b352f70bbbfc17c5a0c4bb9b6ccf1f66) | `` yourkit-java: 2024.9-b164 -> 2025.3-b134 ``                                                          |
| [`3cbe4dca`](https://github.com/NixOS/nixpkgs/commit/3cbe4dca916b2a4d9f87288264638952c628b5c2) | `` pc: 0.4 -> 0.6 ``                                                                                    |
| [`8fd1ef7e`](https://github.com/NixOS/nixpkgs/commit/8fd1ef7eb44820175bbcc05b0a964fb9bc33de4f) | `` rpm-sequoia: 1.7.0 -> 1.8.0 ``                                                                       |
| [`8c31e3f5`](https://github.com/NixOS/nixpkgs/commit/8c31e3f5cb0176dad2dc387ecbb03e45b85fdb6c) | `` ghq: 1.7.1 -> 1.8.0 ``                                                                               |
| [`82c27c21`](https://github.com/NixOS/nixpkgs/commit/82c27c2116cbb654e1c9645cfe6cb1dc868513cc) | `` btcpayserver: 2.0.7 -> 2.0.8 ``                                                                      |
| [`c518a91e`](https://github.com/NixOS/nixpkgs/commit/c518a91efa1bcf70b78a797e2df33d582f82f7f6) | `` keymapper: 4.11.1 -> 4.11.4 ``                                                                       |
| [`8562345e`](https://github.com/NixOS/nixpkgs/commit/8562345e83817140d9ab682f8d0371cdb8500491) | `` ocamlPackages.metadata: 0.3.0 -> 0.3.1 ``                                                            |
| [`d44d9492`](https://github.com/NixOS/nixpkgs/commit/d44d94926c8261bfde5a64a70b00e95d3e9013c0) | `` sentry-native: 0.8.2 -> 0.8.3 ``                                                                     |
| [`758551e4`](https://github.com/NixOS/nixpkgs/commit/758551e4587d75882aebc21a04bee960418f8ce9) | `` refine: fix eval ``                                                                                  |
| [`a3085f21`](https://github.com/NixOS/nixpkgs/commit/a3085f21a97c5709b8b6d8ca194cdb2e65dde69f) | `` hyprgraphics: 0.1.2 -> 0.1.3 ``                                                                      |
| [`2ab1f218`](https://github.com/NixOS/nixpkgs/commit/2ab1f218fb3ec043693480f6224727f2efd46438) | `` nixos/services.mysql: fix galeraCluster.clusterAddress is evaluated before assertions are checked `` |
| [`f9760f52`](https://github.com/NixOS/nixpkgs/commit/f9760f523b3b718d445c3ca0f136b0ccbe2f4b61) | `` python312Packages.orbax-checkpoint: 0.11.10 -> 0.11.11 ``                                            |
| [`7cdf2bbf`](https://github.com/NixOS/nixpkgs/commit/7cdf2bbf3d9a6fb48a28efe191769080281d19ba) | `` jujutsu: 0.28.1 -> 0.28.2 ``                                                                         |
| [`eae90bb6`](https://github.com/NixOS/nixpkgs/commit/eae90bb6c6b41fa398f7dd99be1fa1088c141b08) | `` yaml-language-server: use writableTmpDirAsHomeHook ``                                                |
| [`797ee066`](https://github.com/NixOS/nixpkgs/commit/797ee0663d8204fc032a30d7c9b9eaa1a596b378) | `` yaml-language-server: 1.15.0 -> 1.17.0 ``                                                            |
| [`a37f0b2e`](https://github.com/NixOS/nixpkgs/commit/a37f0b2ed3f61a5d68ae532f33fad2d83df52ea3) | `` python3Packages.youtube-search-python: patch for httpx >= 0.28 (#396845) ``                          |
| [`00fde3a5`](https://github.com/NixOS/nixpkgs/commit/00fde3a5979d0ab7655362ec89c21164bdbfb043) | `` python312Packages.speechbrain: 1.0.2 -> 1.0.3 ``                                                     |
| [`b8e9b34d`](https://github.com/NixOS/nixpkgs/commit/b8e9b34dbbfef7e9f904522ecf32fe40531fe2fa) | `` stown: add nix-update-script ``                                                                      |
| [`eb49b518`](https://github.com/NixOS/nixpkgs/commit/eb49b51810e6e1cee467f8d306711c79a9087d81) | `` python312Packages.tldextract: 5.1.3 -> 5.2.0 ``                                                      |
| [`f181f1c4`](https://github.com/NixOS/nixpkgs/commit/f181f1c4ecddf1778de6983ca34d0f93d1b49891) | `` cosmic-settings-daemon: add drakon64 to maintainers ``                                               |
| [`a1b5951e`](https://github.com/NixOS/nixpkgs/commit/a1b5951e58a288d75cb1567757b7a9c2bf2ca341) | `` maintainers: add drakon64 ``                                                                         |
| [`0d5dc32b`](https://github.com/NixOS/nixpkgs/commit/0d5dc32b97c4530d45bca3e51c612cecb1ec828b) | `` gnucash: 5.10 -> 5.11 (#394973) ``                                                                   |
| [`46f4333e`](https://github.com/NixOS/nixpkgs/commit/46f4333ef257f16be8f796f40ef8a79e74049722) | `` pnpm_10: 10.7.1 -> 10.8.0 ``                                                                         |
| [`651ceef8`](https://github.com/NixOS/nixpkgs/commit/651ceef8830bae895330da43f08db78bfa17fae7) | `` qvge: 0.6.3 -> 0.6.3-unstable-2024-04-08 ``                                                          |
| [`0c80ea2d`](https://github.com/NixOS/nixpkgs/commit/0c80ea2df0df2e52c89a267868e95553aed7abd6) | `` vale: 3.11.1 -> 3.11.2 ``                                                                            |
| [`cbb30bb8`](https://github.com/NixOS/nixpkgs/commit/cbb30bb86cc19f279640344de31cde289a1e1fb1) | `` star-history: 1.0.29 -> 1.0.30 ``                                                                    |
| [`dd1110d1`](https://github.com/NixOS/nixpkgs/commit/dd1110d1b22f5ea6ea3c67ae4ba109f718188227) | `` nushellPlugins.net: 1.8.0 -> 1.9.0 ``                                                                |
| [`14434a98`](https://github.com/NixOS/nixpkgs/commit/14434a98430d7fb6662f79da3990b9d0e379d3d6) | `` rush: add `meta.mainProgram` ``                                                                      |
| [`c4eca4b0`](https://github.com/NixOS/nixpkgs/commit/c4eca4b00d65689757f095ced24ca7be2c9412d4) | `` rush: add c4f3z1n as a maintainer ``                                                                 |
| [`c7f81b98`](https://github.com/NixOS/nixpkgs/commit/c7f81b984f363014eaaba977799d0b769d9758fb) | `` kubelogin-oidc: 1.32.2 -> 1.32.3 ``                                                                  |
| [`65a33360`](https://github.com/NixOS/nixpkgs/commit/65a333600d5c88a98d674f637d092807cfc12253) | `` treewide: replace `rev` with `tag` ``                                                                |
| [`d4afb702`](https://github.com/NixOS/nixpkgs/commit/d4afb70293e08f50f182ac6893aff562ee412cb9) | `` nixosTests.cosmic-autologin-noxwayland: init ``                                                      |
| [`64627fbb`](https://github.com/NixOS/nixpkgs/commit/64627fbbb283b3370a66a6478a46d8c6a260f033) | `` nixosTests.cosmic-noxwayland: init ``                                                                |
| [`3dde381d`](https://github.com/NixOS/nixpkgs/commit/3dde381d9db571fb45b144d8cbb1b5db004e4cee) | `` nixosTests.cosmic-autologin: init ``                                                                 |
| [`d4ea9e9d`](https://github.com/NixOS/nixpkgs/commit/d4ea9e9d2e4c475a8147c2583352abcc7c845cf1) | `` nixosTests.cosmic: init ``                                                                           |
| [`253906b6`](https://github.com/NixOS/nixpkgs/commit/253906b62bc3306924e061beb33954dff17e2ffc) | `` nixosTests: add base configuration for the COSMIC modules' tests ``                                  |
| [`fa7a27b2`](https://github.com/NixOS/nixpkgs/commit/fa7a27b2bc8feb35a344aa3ea458650629771493) | `` vscode-extensions.uiua-lang.uiua-vscode: 0.0.62 -> 0.0.63 ``                                         |
| [`255a0335`](https://github.com/NixOS/nixpkgs/commit/255a0335b7ac40855b7e210ec7ea00b559d630eb) | `` uiua-unstable: 0.15.0 -> 0.15.1 ``                                                                   |
| [`79fe936c`](https://github.com/NixOS/nixpkgs/commit/79fe936cb8a85d90f7b44c7d356e168504adc497) | `` uiua: 0.15.0 -> 0.15.1 ``                                                                            |
| [`0a93df32`](https://github.com/NixOS/nixpkgs/commit/0a93df322d8a8e035527c17201f2d18690881623) | `` cables: 0.5.10 -> 0.5.11 ``                                                                          |
| [`b052de7c`](https://github.com/NixOS/nixpkgs/commit/b052de7c3895558e9c7fd3ec0fe8f7fcabc012f9) | `` prowler: override py-ocsf-models ``                                                                  |
| [`f960e3c8`](https://github.com/NixOS/nixpkgs/commit/f960e3c8528300499d1e2db85ca9a33c72fedcf8) | `` libresplit: 0-unstable-2024-09-24 -> 0-unstable-2025-04-05 ``                                        |
| [`d1f03667`](https://github.com/NixOS/nixpkgs/commit/d1f03667e4e59aae94295b0e32783274ab62daea) | `` principia: 2024.07.12 -> 2025.04.05 ``                                                               |
| [`5cd26233`](https://github.com/NixOS/nixpkgs/commit/5cd2623332baee2f9e0565abef6f91329fbdb32f) | `` nixVersions: drop 2.27 in favour of 2.28 ``                                                          |
| [`492b3f33`](https://github.com/NixOS/nixpkgs/commit/492b3f330f647c1c6db23996cd80dfd79adc7986) | `` networkd-dispatcher: remove unused configparser, use installManPage and --replace-fail ``            |
| [`2025f72a`](https://github.com/NixOS/nixpkgs/commit/2025f72a16ec69daf221a5553e75fdcf2dacb35d) | `` python3Packages.pyghmi: init at 1.5.77 (#383866) ``                                                  |
| [`4a5fb133`](https://github.com/NixOS/nixpkgs/commit/4a5fb133e3a4b3f4c827160bf4fd39129dda5a83) | `` mpls: 0.13.2 -> 0.13.3 ``                                                                            |
| [`03426298`](https://github.com/NixOS/nixpkgs/commit/034262985cd3fad1ae6b849b8c3fad24669d78e7) | `` python312Packages.open-clip-torch: 2.31.0 -> 2.32.0 ``                                               |
| [`4e21d3ba`](https://github.com/NixOS/nixpkgs/commit/4e21d3ba46e457ea5c3b8aa4d1c65780810cbd14) | `` build(deps): bump actions/create-github-app-token from 1.11.7 to 2.0.2 ``                            |
| [`e4bf24ac`](https://github.com/NixOS/nixpkgs/commit/e4bf24acdec0f92d782f497827710ad90b3a01d8) | `` reindeer: 2025.03.24.00 -> 2025.03.31.00 ``                                                          |
| [`54c98362`](https://github.com/NixOS/nixpkgs/commit/54c98362fd736d606992e177ebdc9886f79b6bba) | `` slackdump: 3.0.8 -> 3.0.10 ``                                                                        |